### PR TITLE
changed pylode to pages to push changes to main branch

### DIFF
--- a/.github/workflows/pylode_to_pages.yml
+++ b/.github/workflows/pylode_to_pages.yml
@@ -1,33 +1,42 @@
 name: PyLODE to GitHub Pages
+
 on:
-  push:
-    branches:
-      - main # Set a branch name to trigger deployment
   pull_request:
+    types: [closed]
+  workflow_dispatch:
+
 jobs:
   pylode-to-pages:
+    if: github.event.pull_request.merged == true  # Only run on merged PR
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout main branch
+        uses: actions/checkout@v3
         with:
-          submodules: true # Fetch Hugo themes (true OR recursive)
-          fetch-depth: 0 # Fetch all history for .GitInfo and .Lastmod
+          ref: main
+          fetch-depth: 0
 
       - name: Build Pages
         uses: vliz-be-opsci/pylode-to-pages@v0.1.44
         with:
-          baseuri: https://lab.fairease.eu/asset-standards/
+          baseuri: https://lab.fairease.eu/asset-standards/endpoint-types/
           nsfolder: ./endpoint-types
           outfolder: ./publish
 
       - name: Show contents
-        run: find -L ./publish/ -type f  | grep -v "\./\.git"
+        run: find -L ./publish/ -type f | grep -v "\./\.git"
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Copy generated files to repo root
+        run: |
+          # Remove all files except .git folder
+          git rm -r --ignore-unmatch .
+          # Copy publish contents to root
+          cp -a ./publish/. ./endpoint-types
+
+      - name: Commit and push changes
+        uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./publish/
+          branch: main
+          force: true
+          commit_message: "Deploy updated docs from PR #${{ github.event.pull_request.number }}"


### PR DESCRIPTION
this is because the main branch already has a publishing action that looks at the main branch instead of the gh-pages branch.

The values for endpoint-types are a test. BEWARE that this can cause issues in the current main branch and that a revert my be needed if this fails